### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,47 @@ on:
       - 'layer/**'
       - 'lambdas/**'
       - 'resources/**'
+      - 'docs/**'
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: api
+        template: docs/template.md
+      env:
+        CMX_CLIENT_USER: ${{ secrets.CMX_CLIENT_USER }}
+        CMX_CLIENT_PWD: ${{ secrets.CMX_CLIENT_PWD }}
+        CMX_CUST_ID: ${{ secrets.CMX_CUST_ID }}
+        MWS_KEY_ID: ${{ secrets.MWS_KEY_ID }}
+        MWS_KEY_SECRET: ${{ secrets.MWS_KEY_SECRET }}
+        AMZ_EU_SELLER_ID: ${{ secrets.AMZ_EU_SELLER_ID }}
+        COGNITO_USER_POOL_ARN: ${{ secrets.COGNITO_USER_POOL_ARN }}
+        STOCKS_BUS_ARN: ${{ secrets.EB_STOCKS_BUS_ARN }}
+  deploy:
+    runs-on: ubuntu-latest
+    needs: generate-docs
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Pull latest commit
+      run: |
+        git config pull.rebase false
+        git pull
     - name: Install dependencies
       run: npm i
     - name: serverless check

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,29 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/stocks-api)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/stocks-api?color=blue)
+
+**GitHub Actions workflows status**
+
+[![](https://img.shields.io/github/workflow/status/kaskadi/stocks-api/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/stocks-api/actions?query=workflow%3Adeploy)
+[![](https://img.shields.io/github/workflow/status/kaskadi/stocks-api/build?label=build&logo=mocha)](https://github.com/kaskadi/stocks-api/actions?query=workflow%3Abuild)
+[![](https://img.shields.io/github/workflow/status/kaskadi/stocks-api/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/stocks-api/actions?query=workflow%3Asyntax-check)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/stocks-api?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/stocks-api)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/stocks-api?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/stocks-api)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/stocks-api?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/stocks-api)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/stocks-api?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/stocks-api/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+<!-- You can customize this template as you'd like! -->

--- a/lambdas/request-amz-stock-update/serverless.yml
+++ b/lambdas/request-amz-stock-update/serverless.yml
@@ -20,6 +20,11 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint initialize a stock update for all Amazon stocks of Klimapartner GmbH.
+        queryStringParameters:
+          - key: code
+            description: The code of the marketplace you would like to refresh stocks for. If nothing is specified, this will start an update process for all marketplaces.
   - schedule:
       rate: cron(0 7 ? * * *)
       enabled: true

--- a/lambdas/request-klima-stock-update/serverless.yml
+++ b/lambdas/request-klima-stock-update/serverless.yml
@@ -20,6 +20,8 @@ events:
       authorizer:
         type: COGNITO_USER_POOLS
         authorizerId: !Ref CognitoAuthorizer
+      kaskadi-docs:
+        description: This endpoint initialize a stock update for all in-house stocks at Klimapartner GmbH.
   - schedule:
       rate: cron(0 7 ? * * *)
       enabled: true

--- a/tools/add-lambda/data/serverless.yml
+++ b/tools/add-lambda/data/serverless.yml
@@ -1,5 +1,6 @@
 handler: lambdas/{{name}}/{{name}}.handler
-name: ${self:service.name}-{{name}}-lambda
+name: {{name}}
+# customize as needed to connect your lambda function to layers
 layers:
   - { Ref: ApiLayerLambdaLayer }
 package:
@@ -11,3 +12,21 @@ events:
       method: {{method}}
       path: {{path}}
       cors: true
+      # custom fields allowing you to describe your endpoint in order to automatically document it
+      kaskadi-docs:
+        description: placeholder endpoint # describe what this endpoint is used for
+        # this field helps you describe any query string parameter accepted by this endpoint
+        queryStringParameters:
+          - key: key1
+            description: first key
+          - key: key2
+            description: second key
+            default: 35 # you can give a default value
+        # this field helps you describe the body expected by your endpoint
+        body:
+          - key: param1
+            description: first body param
+            default: 'hello'
+          - key: param2
+            description: second body param
+            default: true

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,11 +1,8 @@
-# Layer
-echo "installing layer"
-echo "changing directory"
-cd layer/nodejs
-echo $(pwd)
-echo "installing dependencies"
-npm i
-echo "done"
-echo "cleaning up"
-cd ../..
-echo $(pwd)
+#!/bin/bash
+
+if [ -d "layer" ] && [ -f "layer/nodejs/package.json" ]
+  then
+    cd layer/nodejs || exit
+    npm i
+    cd ../../
+fi


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` GitHub action.

**New features**
- _docs template:_ template for documentation generation located under `docs/template.md`

**Updated features**
- _`deploy` workflow:_ now includes a `generate-docs` step which automatically generate documentation using `action-generate-docs` and a template located under `docs/template.md`
- _endpoints config file:_ now includes custom `kaskadi-docs` field for documentation generation
- _install script:_ updated install script to handle cases where no layer exists
- _`add-lambda` tool:_ added placeholder `kaskadi-docs` field in base config file